### PR TITLE
Uplift GitHub workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Running tests on Node v${{ matrix.node-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:


### PR DESCRIPTION
Updates the GitHub workflows so that they run on the latest `ubuntu-22.04` image.

https://github.com/medic/cht-core/issues/7741